### PR TITLE
Remove unnecessary boot function

### DIFF
--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -16,16 +16,4 @@ class EventServiceProvider extends ServiceProvider
       'eloquent.deleting: *'  => ['Askedio\SoftCascade\Listeners\CascadeDeleteListener'],
       'eloquent.restoring: *' => ['Askedio\SoftCascade\Listeners\CascadeRestoreListener'],
     ];
-
-    /**
-     * Register any other events for your application.
-     *
-     * @param \Illuminate\Contracts\Events\Dispatcher $events
-     *
-     * @return void
-     */
-    public function boot(DispatcherContract $events)
-    {
-        parent::boot($events);
-    }
 }


### PR DESCRIPTION
The EventServiceProvider boot function it's not necessary because it only calls the same parent function.
Also, removing it, makes this package compatible with Laravel 5.3.
