### PR TITLE
Using query builder to prevent multiple queries and optimized get's

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,11 @@ language: php
 php:
   - "5.6"
   - "7.0"
+  - "7.1"
+  - "hhvm-3.3"
+  - "hhvm-3.6"
+  - "hhvm-3.9"
+  - "hhvm-3.12"
   - "hhvm-3.15"
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,7 @@ php:
   - "5.6"
   - "7.0"
   - "7.1"
-  - "hhvm-3.3"
-  - "hhvm-3.6"
-  - "hhvm-3.9"
-  - "hhvm-3.12"
-  - "hhvm-3.15"
+  - "hhvm"
 
 before_script:
   - curl -sS https://getcomposer.org/installer | php -- --filename=composer

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 php:
   - "5.6"
   - "7.0"
-  - "hhvm"
+  - "hhvm-3.15"
 
 before_script:
   - curl -sS https://getcomposer.org/installer | php -- --filename=composer

--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ User::withTrashed()->limit(2)->restore();
 * 5.6
 * 7.0
 * 7.1
-* HHVM 3.3
-* HHVM 3.6
-* HHVM 3.9
-* HHVM 3.12
-* HHVM 3.15
 
 # Supported Databases
 * MySQL

--- a/README.md
+++ b/README.md
@@ -57,6 +57,16 @@ User::limit(2)->delete();
 User::withTrashed()->limit(2)->restore();
 ~~~
 
+# Supported PHP Versions
+* 5.6
+* 7.0
+* 7.1
+* HHVM 3.3
+* HHVM 3.6
+* HHVM 3.9
+* HHVM 3.12
+* HHVM 3.15
+
 # Supported Databases
 * MySQL
 * SQLite

--- a/src/Contracts/SoftCascadeable.php
+++ b/src/Contracts/SoftCascadeable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Askedio\SoftCascade\Contracts;
+
+/**
+ * TO-DO:
+ * - Support for ON CASCADE SET NULL
+ * - Support for ON CASCADE RESTRICT.
+ */
+interface SoftCascadeable
+{
+    /**
+     * Cascade over Eloquent items.
+     *
+     * @param Illuminate\Database\Eloquent\Model $models
+     * @param string                             $direction update|delete|restore
+     * @param array                              $directionData
+     *
+     * @return void
+     */
+    public function cascade($models, $direction, $directionData = []);
+}

--- a/src/EloquentSoftCascade.php
+++ b/src/EloquentSoftCascade.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Askedio\SoftCascade;
+
+use Askedio\SoftCascade\SoftCascade;
+use Illuminate\Support\Str;
+
+class EloquentSoftCascade extends SoftCascade {}

--- a/src/Listeners/CascadeDeleteListener.php
+++ b/src/Listeners/CascadeDeleteListener.php
@@ -2,7 +2,7 @@
 
 namespace Askedio\SoftCascade\Listeners;
 
-use Askedio\SoftCascade\SoftCascade;
+use Askedio\SoftCascade\EloquentSoftCascade;
 
 class CascadeDeleteListener
 {
@@ -17,6 +17,6 @@ class CascadeDeleteListener
      */
     public function handle($event, $model)
     {
-        (new SoftCascade())->cascade($model, 'delete');
+        (new EloquentSoftCascade())->cascade($model, 'delete');
     }
 }

--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -18,17 +18,14 @@ class CascadeQueryListener
     {
         $debugBacktrace = collect(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 30))->filter(function($backtrace)  {
             return @$backtrace['class'] === $this->listenClass;
-        });
+        })->first();
         $checkBacktrace = null;
-        if (!is_null($debugBacktrace)) {
-            $debugBacktrace = $debugBacktrace->first();
-            if (str_contains(@$debugBacktrace['file'], 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && @$debugBacktrace['function'] == 'update') {
-                $checkBacktrace = [
-                    'object' => $debugBacktrace['object'],
-                    'function' => $debugBacktrace['function'],
-                    'args' => $debugBacktrace['args'][0]
-                ];
-            }
+        if (!is_null($debugBacktrace) && str_contains(@$debugBacktrace['file'], 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && @$debugBacktrace['function'] == 'update') {
+            $checkBacktrace = [
+                'object' => $debugBacktrace['object'],
+                'function' => $debugBacktrace['function'],
+                'args' => $debugBacktrace['args'][0]
+            ];
         }
         return $checkBacktrace;
     }

--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -20,13 +20,15 @@ class CascadeQueryListener
             return @$backtrace['class'] === $this->listenClass;
         });
         $checkBacktrace = null;
-        if (!is_null($debugBacktrace) && str_contains(@$debugBacktrace['file'], 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && @$debugBacktrace['function'] == 'update') {
+        if (!is_null($debugBacktrace)) {
             $debugBacktrace = $debugBacktrace->first();
-            $checkBacktrace = [
-                'object' => $debugBacktrace['object'],
-                'function' => $debugBacktrace['function'],
-                'args' => $debugBacktrace['args'][0]
-            ];
+            if (str_contains(@$debugBacktrace['file'], 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && @$debugBacktrace['function'] == 'update') {
+                $checkBacktrace = [
+                    'object' => $debugBacktrace['object'],
+                    'function' => $debugBacktrace['function'],
+                    'args' => $debugBacktrace['args'][0]
+                ];
+            }
         }
         return $checkBacktrace;
     }

--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -19,12 +19,6 @@ class CascadeQueryListener
         $debugBacktrace = collect(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 30))->filter(function($backtrace)  {
             return @$backtrace['class'] === $this->listenClass;
         })->first();
-        $prueba = collect(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 30))->filter(function($backtrace)  {
-            return str_contains(@$debugBacktrace['file'], 'SoftDeletingScope.php');
-        })->first();
-        if (!is_null($prueba)) {
-            dd($prueba);
-        }
         $checkBacktrace = null;
         if (!is_null($debugBacktrace) && str_contains(@$debugBacktrace['file'], 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && @$debugBacktrace['function'] == 'update') {
             $checkBacktrace = [

--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -18,9 +18,10 @@ class CascadeQueryListener
     {
         $debugBacktrace = collect(debug_backtrace(DEBUG_BACKTRACE_PROVIDE_OBJECT, 30))->filter(function($backtrace)  {
             return @$backtrace['class'] === $this->listenClass;
-        })->first();
+        });
         $checkBacktrace = null;
         if (!is_null($debugBacktrace) && str_contains(@$debugBacktrace['file'], 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && @$debugBacktrace['function'] == 'update') {
+            $debugBacktrace = $debugBacktrace->first();
             $checkBacktrace = [
                 'object' => $debugBacktrace['object'],
                 'function' => $debugBacktrace['function'],

--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -41,7 +41,7 @@ class CascadeQueryListener
      *
      * @return void
      */
-    public function handle($query)
+    public function handle()
     {
         $checkBacktrace = $this->getBacktraceUse();
         if (!is_null($checkBacktrace)) {

--- a/src/Listeners/CascadeRestoreListener.php
+++ b/src/Listeners/CascadeRestoreListener.php
@@ -2,7 +2,7 @@
 
 namespace Askedio\SoftCascade\Listeners;
 
-use Askedio\SoftCascade\SoftCascade;
+use Askedio\SoftCascade\EloquentSoftCascade;
 
 class CascadeRestoreListener
 {
@@ -17,6 +17,6 @@ class CascadeRestoreListener
      */
     public function handle($event, $model)
     {
-        (new SoftCascade())->cascade($model, 'restore');
+        (new EloquentSoftCascade())->cascade($model, 'restore');
     }
 }

--- a/src/Providers/LumenEventServiceProvider.php
+++ b/src/Providers/LumenEventServiceProvider.php
@@ -14,5 +14,6 @@ class LumenEventServiceProvider extends ServiceProvider
     protected $listen = [
       'eloquent.deleting: *'  => ['Askedio\SoftCascade\Listeners\CascadeDeleteListener'],
       'eloquent.restoring: *' => ['Askedio\SoftCascade\Listeners\CascadeRestoreListener'],
+      'Illuminate\Database\Events\QueryExecuted' => ['Askedio\SoftCascade\Listeners\CascadeQueryListener']
     ];
 }

--- a/src/QueryBuilderSoftCascade.php
+++ b/src/QueryBuilderSoftCascade.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Askedio\SoftCascade;
+
+use Askedio\SoftCascade\SoftCascade;
+use Illuminate\Support\Str;
+
+class QueryBuilderSoftCascade extends SoftCascade {}

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -95,11 +95,7 @@ class SoftCascade implements SoftCascadeable
         $relationModel = new $relationModel();
         $relationModel = $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds);
         $this->run($relationModel->get([$relationModel->getModel()->getKeyName()]));
-        if (empty($this->directionData)) {
-            $relationModel->{$this->direction}();
-        } else {
-            $relationModel->{$this->direction}($this->directionData);
-        }
+        $relationModel->{$this->direction}($this->directionData);
     }
 
     /**

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -56,11 +56,34 @@ class IntegrationTest extends BaseTestCase
         $this->assertDatabaseMissing('addresses', ['deleted_at' => null]);
     }
 
+    public function testDeleteQueryBuilder()
+    {
+        $this->createUserRaw();
+
+        User::whereIn('id',[1])->delete();
+
+        $this->assertDatabaseMissing('users', ['deleted_at' => null]);
+        $this->assertDatabaseMissing('profiles', ['deleted_at' => null]);
+        $this->assertDatabaseMissing('addresses', ['deleted_at' => null]);
+    }
+
     public function testRestore()
     {
         $this->createUserRaw();
 
         User::first()->delete();
+        User::withTrashed()->first()->restore();
+
+        $this->assertDatabaseHas('users', ['deleted_at' => null]);
+        $this->assertDatabaseHas('profiles', ['deleted_at' => null]);
+        $this->assertDatabaseHas('addresses', ['deleted_at' => null]);
+    }
+
+    public function testRestoreQueryBuilder()
+    {
+        $this->createUserRaw();
+
+        User::whereIn('id',[1])->delete();
         User::withTrashed()->first()->restore();
 
         $this->assertDatabaseHas('users', ['deleted_at' => null]);

--- a/tests/LumenIntegrationTest.php
+++ b/tests/LumenIntegrationTest.php
@@ -56,11 +56,34 @@ class LumenIntegrationTest extends LumenBaseTestCase
         $this->assertDatabaseMissing('addresses', ['deleted_at' => null]);
     }
 
+    public function testDeleteQueryBuilder()
+    {
+        $this->createUserRaw();
+
+        User::whereIn('id',[1])->delete();
+
+        $this->assertDatabaseMissing('users', ['deleted_at' => null]);
+        $this->assertDatabaseMissing('profiles', ['deleted_at' => null]);
+        $this->assertDatabaseMissing('addresses', ['deleted_at' => null]);
+    }
+
     public function testRestore()
     {
         $this->createUserRaw();
 
         User::first()->delete();
+        User::withTrashed()->first()->restore();
+
+        $this->assertDatabaseHas('users', ['deleted_at' => null]);
+        $this->assertDatabaseHas('profiles', ['deleted_at' => null]);
+        $this->assertDatabaseHas('addresses', ['deleted_at' => null]);
+    }
+
+    public function testRestoreQueryBuilder()
+    {
+        $this->createUserRaw();
+
+        User::whereIn('id',[1])->delete();
         User::withTrashed()->first()->restore();
 
         $this->assertDatabaseHas('users', ['deleted_at' => null]);


### PR DESCRIPTION
All queries use query builder whereIn to prevent to much queries and the select only get primaryKey field.