### PR TITLE
add (failing) test with morphOne

### DIFF
--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -35,7 +35,7 @@ class SoftCascade implements SoftCascadeable
             DB::commit(); //All ok we commit all database queries
         } catch (\Exception $e) {
             DB::rollBack(); //Rollback the transaction before throw exception
-            throw new SoftCascadeLogicException($e->getMessage());
+            throw new SoftCascadeLogicException($e->getMessage(), null, $e);
         }
     }
 

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -6,6 +6,8 @@ use Askedio\SoftCascade\Contracts\SoftCascadeable;
 use Askedio\SoftCascade\Exceptions\SoftCascadeLogicException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeNonExistentRelationActionException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeRestrictedException;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
 use Illuminate\Support\Facades\DB;
 
 class SoftCascade implements SoftCascadeable
@@ -89,10 +91,9 @@ class SoftCascade implements SoftCascadeable
             $foreignKeyIdsUse = $foreignKeyIds;
 
             //Many to many relations need to get related ids and related local key
-            $classModelRelation = get_class($modelRelation);
-            if ($classModelRelation == 'Illuminate\Database\Eloquent\Relations\BelongsToMany') {
+            if ($modelRelation instanceof BelongsToMany) {
                 extract($this->getBelongsToManyData($modelRelation, $foreignKeyIds));
-            } elseif ($classModelRelation == 'Illuminate\Database\Eloquent\Relations\MorphMany') {
+            } elseif ($modelRelation instanceof MorphOneOrMany) {
                 extract($this->getMorphManyData($modelRelation, $foreignKeyIds));
             }
 

--- a/tests/App/RoleReader.php
+++ b/tests/App/RoleReader.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Askedio\Tests\App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RoleReader extends Model
+{
+    use \Illuminate\Database\Eloquent\SoftDeletes;
+    use \Askedio\SoftCascade\Traits\SoftCascadeTrait;
+
+    protected $table = 'readers';
+
+    protected $fillable = ['reader_name'];
+    
+    protected $softCascade = ['user'];
+
+    /**
+     * Get all of the post's comments.
+     */
+    public function user()
+    {
+        return $this->morphOne('Askedio\Tests\App\User', 'role');
+    }
+}

--- a/tests/App/RoleReader.php
+++ b/tests/App/RoleReader.php
@@ -12,7 +12,7 @@ class RoleReader extends Model
     protected $table = 'readers';
 
     protected $fillable = ['reader_name'];
-    
+
     protected $softCascade = ['user'];
 
     /**

--- a/tests/App/RoleWriter.php
+++ b/tests/App/RoleWriter.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Askedio\Tests\App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class RoleWriter extends Model
+{
+    use \Illuminate\Database\Eloquent\SoftDeletes;
+    use \Askedio\SoftCascade\Traits\SoftCascadeTrait;
+
+    protected $table = 'writers';
+
+    protected $fillable = ['writer_name'];
+    
+    protected $softCascade = ['user'];
+    
+    /**
+     * Get all of the post's comments.
+     */
+    public function user()
+    {
+        return $this->morphOne('Askedio\Tests\App\User', 'role');
+    }
+}

--- a/tests/App/RoleWriter.php
+++ b/tests/App/RoleWriter.php
@@ -12,9 +12,9 @@ class RoleWriter extends Model
     protected $table = 'writers';
 
     protected $fillable = ['writer_name'];
-    
+
     protected $softCascade = ['user'];
-    
+
     /**
      * Get all of the post's comments.
      */

--- a/tests/App/User.php
+++ b/tests/App/User.php
@@ -19,11 +19,9 @@ class User extends Model
     {
         return $this->hasMany('Askedio\Tests\App\Profiles');
     }
-    
+
     public function role()
     {
         return $this->morphTo();
     }
-    
-    
 }

--- a/tests/App/User.php
+++ b/tests/App/User.php
@@ -19,4 +19,11 @@ class User extends Model
     {
         return $this->hasMany('Askedio\Tests\App\Profiles');
     }
+    
+    public function role()
+    {
+        return $this->morphTo();
+    }
+    
+    
 }

--- a/tests/App/database/migrations/2017_09_07_111606_create_writers_table.php
+++ b/tests/App/database/migrations/2017_09_07_111606_create_writers_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateUsersTable extends Migration
+class CreateWritersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -12,13 +12,9 @@ class CreateUsersTable extends Migration
      */
     public function up()
     {
-        DB::connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+        DB::connection()->getSchemaBuilder()->create('writers', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->string('password', 60);
-            $table->nullableMorphs('role');
-            $table->rememberToken();
+            $table->string('writer_name', 255);
             $table->timestamps();
             $table->softDeletes();
         });
@@ -31,6 +27,6 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
-        DB::connection()->getSchemaBuilder()->dropIfExists('users');
+        DB::connection()->getSchemaBuilder()->dropIfExists('writers');
     }
 }

--- a/tests/App/database/migrations/2017_09_07_111842_create_readers_table.php
+++ b/tests/App/database/migrations/2017_09_07_111842_create_readers_table.php
@@ -3,7 +3,7 @@
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 
-class CreateUsersTable extends Migration
+class CreateReadersTable extends Migration
 {
     /**
      * Run the migrations.
@@ -12,13 +12,9 @@ class CreateUsersTable extends Migration
      */
     public function up()
     {
-        DB::connection()->getSchemaBuilder()->create('users', function (Blueprint $table) {
+        DB::connection()->getSchemaBuilder()->create('readers', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('name');
-            $table->string('email')->unique();
-            $table->string('password', 60);
-            $table->nullableMorphs('role');
-            $table->rememberToken();
+            $table->string('reader_name', 255);
             $table->timestamps();
             $table->softDeletes();
         });
@@ -31,6 +27,6 @@ class CreateUsersTable extends Migration
      */
     public function down()
     {
-        DB::connection()->getSchemaBuilder()->dropIfExists('users');
+        DB::connection()->getSchemaBuilder()->dropIfExists('readers');
     }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -10,8 +10,8 @@ use Askedio\Tests\App\Comment;
 use Askedio\Tests\App\Languages;
 use Askedio\Tests\App\Post;
 use Askedio\Tests\App\Profiles;
-use Askedio\Tests\App\RoleWriter;
 use Askedio\Tests\App\RoleReader;
+use Askedio\Tests\App\RoleWriter;
 use Askedio\Tests\App\User;
 use Askedio\Tests\App\Video;
 
@@ -71,7 +71,7 @@ class IntegrationTest extends BaseTestCase
     {
         $writer = RoleWriter::create([
             'writer_name' => 'Lisa',
-            'id'          => 1
+            'id'          => 1,
         ])->user()->save(new User([
             'name'     => 'admin',
             'email'    => uniqid().'@localhost.com',
@@ -80,7 +80,7 @@ class IntegrationTest extends BaseTestCase
 
         $reader = RoleReader::create([
             'reader_name' => 'Frank',
-            'id'          => 1
+            'id'          => 1,
         ])->user()->save(new User([
             'name'     => 'admin',
             'email'    => uniqid().'@localhost.com',

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -10,10 +10,10 @@ use Askedio\Tests\App\Comment;
 use Askedio\Tests\App\Languages;
 use Askedio\Tests\App\Post;
 use Askedio\Tests\App\Profiles;
-use Askedio\Tests\App\User;
-use Askedio\Tests\App\Video;
 use Askedio\Tests\App\RoleWriter;
 use Askedio\Tests\App\RoleReader;
+use Askedio\Tests\App\User;
+use Askedio\Tests\App\Video;
 
 /**
  *  TO-DO: Need better testing.
@@ -44,6 +44,7 @@ class IntegrationTest extends BaseTestCase
 
         // lazy
         Profiles::first()->address()->create(['languages_id' => 1, 'city' => 'Los Angeles']);
+
         return $user;
     }
 
@@ -65,21 +66,21 @@ class IntegrationTest extends BaseTestCase
 
         return $this;
     }
-    
+
     private function createRoleRaw()
     {
         $writer = RoleWriter::create([
             'writer_name' => 'Lisa',
-            'id' => 1
+            'id'          => 1
         ])->user()->save(new User([
             'name'     => 'admin',
             'email'    => uniqid().'@localhost.com',
             'password' => bcrypt('password'),
         ]));
-            
+
         $reader = RoleReader::create([
             'reader_name' => 'Frank',
-            'id' => 1
+            'id'          => 1
         ])->user()->save(new User([
             'name'     => 'admin',
             'email'    => uniqid().'@localhost.com',
@@ -92,7 +93,7 @@ class IntegrationTest extends BaseTestCase
     public function testPolymorphicManyRelation()
     {
         $this->createCommentRaw();
-        
+
         Post::first()->delete();
 
         $this->assertDatabaseHas('videos', ['deleted_at' => null]);
@@ -100,18 +101,17 @@ class IntegrationTest extends BaseTestCase
         $this->assertDatabaseMissing('posts', ['deleted_at' => null]);
         $this->assertDatabaseMissing('comments', ['commentable_type' => 'Askedio\Tests\App\Post', 'deleted_at' => null]);
     }
-    
+
     public function testPolymorphicOneRelation()
     {
         $this->createRoleRaw();
 
         RoleWriter::first()->delete();
-        
+
         $this->assertDatabaseMissing('writers', ['deleted_at' => null]);
         $this->assertDatabaseMissing('users', ['role_type' => 'Askedio\Tests\App\RoleWriter', 'deleted_at' => null]);
         $this->assertDatabaseHas('readers', ['deleted_at' => null]);
         $this->assertDatabaseHas('users', ['role_type' => 'Askedio\Tests\App\RoleReader', 'deleted_at' => null]);
-        
     }
 
     public function testBadRelation()


### PR DESCRIPTION
When using a `->morphOne` relation the casade doesn't work as expected. The delete query seems not to take into account the morph type of the object.

In the test case written (*testPolymorphicOneRelation*) here, boths the users with the same `role_id = 1` are deleted, when it is expected that only the one with `role_type = 'Askedio\Tests\App\RoleWriter'` is deleted.

I'm trying to investigate further and to find a fix, with no success until now. Maybe because [there is no specific method](https://github.com/Askedio/laravel5-soft-cascade/blob/master/src/SoftCascade.php#L91) to retrieve the related ids and local key for a MorphOne relation ?