### PR TITLE
Already deleted items should not be in the affectedRows when

### DIFF
--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -199,7 +199,12 @@ class SoftCascade implements SoftCascadeable
         $relationModel = $relation->getQuery()->getModel();
         $relationModel = new $relationModel();
         if ($affectedRows > 0) {
-            $relationModel = $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
+        	if ($this->direction == 'delete') {
+        		$relationModel = $relationModel->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
+        	}
+        	else {
+        		$relationModel = $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
+        	}
             $this->run($relationModel->get([$relationModel->getModel()->getKeyName()]));
             $relationModel->{$this->direction}($this->directionData);
         }
@@ -252,8 +257,12 @@ class SoftCascade implements SoftCascadeable
     {
         $relationModel = $relation->getQuery()->getModel();
         $relationModel = new $relationModel();
-
-        return $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->count();
+        if ($this->direction == 'delete') {
+        	return $relationModel->whereIn($foreignKey, $foreignKeyIds)->count();
+        }
+        else {
+        	return $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->count();
+        }
     }
 
     /**

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -199,12 +199,12 @@ class SoftCascade implements SoftCascadeable
         $relationModel = $relation->getQuery()->getModel();
         $relationModel = new $relationModel();
         if ($affectedRows > 0) {
-        	if ($this->direction == 'delete') {
-        		$relationModel = $relationModel->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
-        	}
-        	else {
-        		$relationModel = $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
-        	}
+            if ($this->direction == 'delete') {
+                $relationModel = $relationModel->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
+            }
+            else {
+                $relationModel = $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
+            }
             $this->run($relationModel->get([$relationModel->getModel()->getKeyName()]));
             $relationModel->{$this->direction}($this->directionData);
         }
@@ -258,10 +258,10 @@ class SoftCascade implements SoftCascadeable
         $relationModel = $relation->getQuery()->getModel();
         $relationModel = new $relationModel();
         if ($this->direction == 'delete') {
-        	return $relationModel->whereIn($foreignKey, $foreignKeyIds)->count();
+            return $relationModel->whereIn($foreignKey, $foreignKeyIds)->count();
         }
         else {
-        	return $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->count();
+            return $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->count();
         }
     }
 

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -201,8 +201,7 @@ class SoftCascade implements SoftCascadeable
         if ($affectedRows > 0) {
             if ($this->direction == 'delete') {
                 $relationModel = $relationModel->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
-            }
-            else {
+            } else {
                 $relationModel = $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
             }
             $this->run($relationModel->get([$relationModel->getModel()->getKeyName()]));
@@ -259,8 +258,7 @@ class SoftCascade implements SoftCascadeable
         $relationModel = new $relationModel();
         if ($this->direction == 'delete') {
             return $relationModel->whereIn($foreignKey, $foreignKeyIds)->count();
-        }
-        else {
+        } else {
             return $relationModel->withTrashed()->whereIn($foreignKey, $foreignKeyIds)->count();
         }
     }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -248,6 +248,26 @@ class IntegrationTest extends TestCase
         $this->assertEquals(1, Profiles::count());
     }
 
+    public function testKeepDeletedDates()
+    {
+   		$this->createPostAndCategoriesRaw();
+   		
+   		$post=Post::first();
+   		$post->deleted_at = '2011-01-01';
+   		$post->save();
+   		$this->assertSoftDeleted('posts', ['id' => $post->id]);
+
+   		$categoryToDelete = Category::with('posts')->first();
+   		$categoryToDelete->delete();
+    		
+   		$this->assertSoftDeleted('categories', ['id' => $categoryToDelete->id]);
+   		$categoryToDelete->posts->each(function ($post) {
+   			$this->assertSoftDeleted('posts', ['id' => $post->id]);
+   		});
+   		$posts=Post::withTrashed()->get();
+   		$this->assertNotEquals($posts->first()->deleted_at, $posts->last()->deleted_at);
+    }
+   
     public function testMultipleRestore()
     {
         $this->createUserRaw();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -250,24 +250,24 @@ class IntegrationTest extends TestCase
 
     public function testKeepDeletedDates()
     {
-   		$this->createPostAndCategoriesRaw();
-   		
-   		$post=Post::first();
-   		$post->deleted_at = '2011-01-01';
-   		$post->save();
-   		$this->assertSoftDeleted('posts', ['id' => $post->id]);
+        $this->createPostAndCategoriesRaw();
 
-   		$categoryToDelete = Category::with('posts')->first();
-   		$categoryToDelete->delete();
+        $post=Post::first();
+   	    $post->deleted_at = '2011-01-01';
+   	    $post->save();
+   	    $this->assertSoftDeleted('posts', ['id' => $post->id]);
+
+   	    $categoryToDelete = Category::with('posts')->first();
+   	    $categoryToDelete->delete();
     		
-   		$this->assertSoftDeleted('categories', ['id' => $categoryToDelete->id]);
-   		$categoryToDelete->posts->each(function ($post) {
-   			$this->assertSoftDeleted('posts', ['id' => $post->id]);
-   		});
-   		$posts=Post::withTrashed()->get();
-   		$this->assertNotEquals($posts->first()->deleted_at, $posts->last()->deleted_at);
+   	    $this->assertSoftDeleted('categories', ['id' => $categoryToDelete->id]);
+   	    $categoryToDelete->posts->each(function ($post) {
+   	    	$this->assertSoftDeleted('posts', ['id' => $post->id]);
+   	    });
+   	    $posts=Post::withTrashed()->get();
+   	    $this->assertNotEquals($posts->first()->deleted_at, $posts->last()->deleted_at);
     }
-   
+
     public function testMultipleRestore()
     {
         $this->createUserRaw();

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -252,7 +252,7 @@ class IntegrationTest extends TestCase
     {
         $this->createPostAndCategoriesRaw();
 
-        $post=Post::first();
+        $post = Post::first();
         $post->deleted_at = '2011-01-01';
         $post->save();
 
@@ -265,7 +265,7 @@ class IntegrationTest extends TestCase
         $categoryToDelete->posts->each(function ($post) {
             $this->assertSoftDeleted('posts', ['id' => $post->id]);
         });
-        $posts=Post::withTrashed()->get();
+        $posts = Post::withTrashed()->get();
         $this->assertNotEquals($posts->first()->deleted_at, $posts->last()->deleted_at);
     }
 

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -253,19 +253,20 @@ class IntegrationTest extends TestCase
         $this->createPostAndCategoriesRaw();
 
         $post=Post::first();
-   	    $post->deleted_at = '2011-01-01';
-   	    $post->save();
-   	    $this->assertSoftDeleted('posts', ['id' => $post->id]);
+        $post->deleted_at = '2011-01-01';
+        $post->save();
 
-   	    $categoryToDelete = Category::with('posts')->first();
-   	    $categoryToDelete->delete();
-    		
-   	    $this->assertSoftDeleted('categories', ['id' => $categoryToDelete->id]);
-   	    $categoryToDelete->posts->each(function ($post) {
-   	    	$this->assertSoftDeleted('posts', ['id' => $post->id]);
-   	    });
-   	    $posts=Post::withTrashed()->get();
-   	    $this->assertNotEquals($posts->first()->deleted_at, $posts->last()->deleted_at);
+        $this->assertSoftDeleted('posts', ['id' => $post->id]);
+
+        $categoryToDelete = Category::with('posts')->first();
+        $categoryToDelete->delete();
+
+        $this->assertSoftDeleted('categories', ['id' => $categoryToDelete->id]);
+        $categoryToDelete->posts->each(function ($post) {
+            $this->assertSoftDeleted('posts', ['id' => $post->id]);
+        });
+        $posts=Post::withTrashed()->get();
+        $this->assertNotEquals($posts->first()->deleted_at, $posts->last()->deleted_at);
     }
 
     public function testMultipleRestore()


### PR DESCRIPTION
softcascade should not change deleted_at timestamps of already deleted childmodels, becaus this could break unique Indexes on pivot tables.
E.g. i had a parent model wich contains n child models at position 0..n. to ensure each position is only user once for every parent i created a unique index over the columns parent.id,position and deleted_at in the pivot table. when deleteing the parent Model softcascade tries to change all of the related childmodels to the same deleted_at timestamp, which will not work with the unique index. As i can't see no use in changing all the timestamp of already deleted items, i made this PR
Kind Regards
Tom