### PR TITLE
Add support for Laravel 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,15 @@
     "description": "Laravel Cascade Soft Delete & Restore",
     "type": "library",
     "require": {
-        "php": "^7.1.3",
-        "illuminate/support": "5.8.*",
-        "illuminate/container": "5.8.*",
-        "illuminate/database": "5.8.*",
-        "illuminate/events": "5.8.*"
+        "php": "^7.1.3|^7.2",
+        "illuminate/support": "^5.8|^6.0",
+        "illuminate/container": "^5.8|^6.0",
+        "illuminate/database": "^5.8|^6.0",
+        "illuminate/events": "^5.8|^6.0"
      },
      "require-dev": {
-        "phpunit/phpunit": "~7.5",
-        "orchestra/testbench": "~3.0",
+        "phpunit/phpunit": "~7.5|~8.0",
+        "orchestra/testbench": "~3.0|~4.0",
         "codacy/coverage": "dev-master"
      },
     "autoload": {

--- a/src/Exceptions/SoftCascadeRestrictedException.php
+++ b/src/Exceptions/SoftCascadeRestrictedException.php
@@ -2,6 +2,7 @@
 
 namespace Askedio\SoftCascade\Exceptions;
 
+use Illuminate\Support\Arr;
 use RuntimeException;
 
 class SoftCascadeRestrictedException extends RuntimeException
@@ -40,7 +41,7 @@ class SoftCascadeRestrictedException extends RuntimeException
     {
         $this->model = $model;
         $this->foreignKey = $foreignKey;
-        $this->foreignKeyIds = array_wrap($foreignKeyIds);
+        $this->foreignKeyIds = Arr::wrap($foreignKeyIds);
 
         $this->message = "Integrity constraint violation [{$model}] where $foreignKey in (".implode(', ', $foreignKeyIds).')';
 

--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -3,6 +3,7 @@
 namespace Askedio\SoftCascade\Listeners;
 
 use Askedio\SoftCascade\QueryBuilderSoftCascade;
+use Illuminate\Support\Str;
 
 class CascadeQueryListener
 {
@@ -23,7 +24,7 @@ class CascadeQueryListener
         $checkBacktrace = null;
         $backtraceFile = (isset($debugBacktrace['file'])) ? $debugBacktrace['file'] : null;
         $backtraceFunction = (isset($debugBacktrace['function'])) ? $debugBacktrace['function'] : null;
-        if (!is_null($debugBacktrace) && str_contains($backtraceFile, 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && $backtraceFunction == 'update') {
+        if (!is_null($debugBacktrace) && Str::contains($backtraceFile, 'Illuminate/Database/Eloquent/SoftDeletingScope.php') && $backtraceFunction == 'update') {
             $checkBacktrace = [
                 'object'   => $debugBacktrace['object'],
                 'function' => $debugBacktrace['function'],


### PR DESCRIPTION
I know there's already a PR created for this matter, but it needed further changes.

PHPUnit and Testbench need to be updated as well. Also, `str_` and `array_` helpers were removed from the core so the tests failed with a L6 installation.