### PR TITLE
Set 'update' as a default action if action is null.

### DIFF
--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -274,14 +274,9 @@ class SoftCascade implements SoftCascadeable
      */
     protected function relationResolver($relation)
     {
-        $return = ['relation' => '', 'action' => 'update'];
-
-        try {
-            list($relation, $action) = explode('@', $relation);
-            $return = ['relation' => $relation, 'action' => $action];
-        } catch (\Exception $e) {
-            $return['relation'] = $relation;
-        }
+        $parsedAction = explode('@', $relation);
+        $return['relation'] = $parsedAction[0];
+        $return['action'] = isset($parsedAction[1]) ? $parsedAction[1] : 'update';
 
         if (!in_array($return['action'], $this->availableActions)) {
             DB::rollBack(); //Rollback the transaction before throw exception


### PR DESCRIPTION
Now, I can't use only relation name in $softCascade variable. If a set $softCascade variable as a like this;

_in Post model_
```protected $softCascade = ['comments'];```

I get this exception;

```Askedio/SoftCascade/Exceptions/SoftCascadeLogicException with message 'Non existing relation action [comments@]'```

So, I added 'update' action as a default action if action is null. Now, I can use $softCascade variable elements without action.