### PR TITLE
Fixed Exception if Cascaded Models are not SoftDeleted

### DIFF
--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -173,9 +173,9 @@ class SoftCascade implements SoftCascadeable
     {
         $relatedClass = $relation->getRelated();
         $foreignKeyUse = $relatedClass->getKeyName();
-        $baseQuery = $this->direction === 'delete'
-        ? $relatedClass::query()
-        : $relatedClass::withTrashed();
+        $baseQuery = $this->direction !== 'delete' && method_exists($relatedClass, 'withTrashed')
+        ? $relatedClass::withTrashed()
+        : $relatedClass::query();
         $foreignKeyIdsUse = $baseQuery->where($relation->getMorphType(), $relation->getMorphClass())
             ->whereIn($relation->getQualifiedForeignKeyName(), $foreignKeyIds)
             ->select($foreignKeyUse)
@@ -203,7 +203,7 @@ class SoftCascade implements SoftCascadeable
         $relationModel = $relation->getQuery()->getModel();
         $relationModel = new $relationModel();
         if ($affectedRows > 0) {
-            if ($this->direction != 'delete') {
+            if ($this->direction !== 'delete' && method_exists($relationModel, 'withTrashed')) {
                 $relationModel = $relationModel->withTrashed();
             }
 
@@ -264,7 +264,7 @@ class SoftCascade implements SoftCascadeable
         $relationModel = $relation->getQuery()->getModel();
         $relationModel = new $relationModel();
 
-        if ($this->direction != 'delete') {
+        if ($this->direction !== 'delete' && method_exists($relationModel, 'withTrashed')) {
             $relationModel = $relationModel->withTrashed();
         }
 


### PR DESCRIPTION
I found an issue, when a SoftDeleted model should delete a NotSoftDeleted model. The `CascadeQueryListener` triggers an update, and tries to update the `deleted_at`-columns, which does only exist, if the model uses SoftDeletes.

My use-case is an edge-case, but still valid, I think. I have this model structure:

```
Group(SoftDeleted) > Device(SoftDeleted) > Logs
```

Logs are not SoftDeleted, as they are very short-lived anyway. They have no SoftDelete, and are lost if the Device is deleted. This works without issues.

If the Group is deleted, it does CascadeDelete the Device, which then should CascadeDelete the Logs (hard delete). But this triggers also an `update()` somewhere, and because updated query `withTrashed()`, the transaction fails.

With this rather quick fix, `withTrashed()` should only be called if the model is SoftDeletable.