### PR TITLE
Support CascadeDeletes of models without SoftDelete

### DIFF
--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -11,10 +11,10 @@ use Illuminate\Support\Str;
 
 class CascadeQueryListener
 {
-    CONST EVENT = QueryExecuted::class;
+    const EVENT = QueryExecuted::class;
 
     /**
-     * Check in the backtrace, if models where updated by Builder::delete() or Builder::update()
+     * Check in the backtrace, if models where updated by Builder::delete() or Builder::update().
      */
     private function checkForCascadeEvent(): ?array
     {
@@ -24,15 +24,15 @@ class CascadeQueryListener
         // as otherwise the cascade might be triggered multiple times per user call.
         $queryExecutedEventLimit = 2;
         $traces = $traces->takeUntil(function (array $backtrace) use (&$queryExecutedEventLimit) {
-                $btClass = $backtrace['class'] ?? null;
-                $btFunction = $backtrace['function'] ?? null;
-                $btEvent = $backtrace['args'][0] ?? null;
-                if ($btClass === Connection::class && $btFunction  === 'event' && $btEvent === static::EVENT) {
-                    $queryExecutedEventLimit = $queryExecutedEventLimit - 1;
-                }
+            $btClass = $backtrace['class'] ?? null;
+            $btFunction = $backtrace['function'] ?? null;
+            $btEvent = $backtrace['args'][0] ?? null;
+            if ($btClass === Connection::class && $btFunction === 'event' && $btEvent === static::EVENT) {
+                $queryExecutedEventLimit = $queryExecutedEventLimit - 1;
+            }
 
-                return $queryExecutedEventLimit <= 0;
-            });
+            return $queryExecutedEventLimit <= 0;
+        });
 
         foreach ($traces as $backtrace) {
             $btClass = $backtrace['class'] ?? null;
@@ -46,18 +46,18 @@ class CascadeQueryListener
             // check for all deletes
             if ($btFunction === 'delete') {
                 return [
-                    'builder' => $backtrace['object'],
-                    'direction' => $btFunction,
-                    'directionData' => []
+                    'builder'       => $backtrace['object'],
+                    'direction'     => $btFunction,
+                    'directionData' => [],
                 ];
             }
 
             // check for updates, which where triggered from SoftDelete (set or unset deleted_at-column)
             if ($btFunction === 'update' && Str::contains($btFile, SoftDeletingScope::class)) {
                 return [
-                    'builder' => $backtrace['object'],
-                    'direction' => $btFunction,
-                    'directionData' => $backtrace['args'][0]
+                    'builder'       => $backtrace['object'],
+                    'direction'     => $btFunction,
+                    'directionData' => $backtrace['args'][0],
                 ];
             }
         }

--- a/src/Providers/EventServiceProvider.php
+++ b/src/Providers/EventServiceProvider.php
@@ -2,6 +2,9 @@
 
 namespace Askedio\SoftCascade\Providers;
 
+use Askedio\SoftCascade\Listeners\CascadeDeleteListener;
+use Askedio\SoftCascade\Listeners\CascadeQueryListener;
+use Askedio\SoftCascade\Listeners\CascadeRestoreListener;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -12,8 +15,8 @@ class EventServiceProvider extends ServiceProvider
      * @var array
      */
     protected $listen = [
-        'eloquent.deleting: *'                     => ['Askedio\SoftCascade\Listeners\CascadeDeleteListener'],
-        'eloquent.restoring: *'                    => ['Askedio\SoftCascade\Listeners\CascadeRestoreListener'],
-        'Illuminate\Database\Events\QueryExecuted' => ['Askedio\SoftCascade\Listeners\CascadeQueryListener'],
+        'eloquent.deleting: *'          => [CascadeDeleteListener::class],
+        'eloquent.restoring: *'         => [CascadeRestoreListener::class],
+        CascadeQueryListener::EVENT     => [CascadeQueryListener::class],
     ];
 }

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -6,8 +6,10 @@ use Askedio\SoftCascade\Contracts\SoftCascadeable;
 use Askedio\SoftCascade\Exceptions\SoftCascadeLogicException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeNonExistentRelationActionException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeRestrictedException;
+use BadMethodCallException;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 class SoftCascade implements SoftCascadeable
@@ -173,9 +175,9 @@ class SoftCascade implements SoftCascadeable
     {
         $relatedClass = $relation->getRelated();
         $foreignKeyUse = $relatedClass->getKeyName();
-        $baseQuery = $this->direction === 'delete'
-        ? $relatedClass::query()
-        : $relatedClass::withTrashed();
+
+        $baseQuery = $this->withTrashed($relatedClass::query());
+
         $foreignKeyIdsUse = $baseQuery->where($relation->getMorphType(), $relation->getMorphClass())
             ->whereIn($relation->getQualifiedForeignKeyName(), $foreignKeyIds)
             ->select($foreignKeyUse)
@@ -201,11 +203,8 @@ class SoftCascade implements SoftCascadeable
     protected function execute($relation, $foreignKey, $foreignKeyIds, $affectedRows)
     {
         $relationModel = $relation->getQuery()->getModel();
-        $relationModel = new $relationModel();
         if ($affectedRows > 0) {
-            if ($this->direction != 'delete') {
-                $relationModel = $relationModel->withTrashed();
-            }
+            $relationModel = $this->withTrashed($relationModel::query());
 
             $relationModel = $relationModel->whereIn($foreignKey, $foreignKeyIds)->limit($affectedRows);
 
@@ -262,11 +261,7 @@ class SoftCascade implements SoftCascadeable
     protected function affectedRows($relation, $foreignKey, $foreignKeyIds)
     {
         $relationModel = $relation->getQuery()->getModel();
-        $relationModel = new $relationModel();
-
-        if ($this->direction != 'delete') {
-            $relationModel = $relationModel->withTrashed();
-        }
+        $relationModel = $this->withTrashed($relationModel::query());
 
         return $relationModel->whereIn($foreignKey, $foreignKeyIds)->count();
     }
@@ -291,5 +286,19 @@ class SoftCascade implements SoftCascadeable
         }
 
         return $return;
+    }
+
+    protected function withTrashed(Builder $builder): Builder
+    {
+        if ($this->direction === 'delete') {
+            return $builder;
+        }
+
+        // if the Model does not use SoftDeletes, withTrashed() will be unavailable.
+        try {
+            return $builder->withTrashed();
+        } catch (BadMethodCallException) {
+            return $builder;
+        }
     }
 }

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -7,9 +7,9 @@ use Askedio\SoftCascade\Exceptions\SoftCascadeLogicException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeNonExistentRelationActionException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeRestrictedException;
 use BadMethodCallException;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 
 class SoftCascade implements SoftCascadeable

--- a/tests/App/Addresses.php
+++ b/tests/App/Addresses.php
@@ -7,8 +7,11 @@ use Illuminate\Database\Eloquent\Model;
 class Addresses extends Model
 {
     use \Illuminate\Database\Eloquent\SoftDeletes;
+    use \Askedio\SoftCascade\Traits\SoftCascadeTrait;
 
     protected $fillable = ['languages_id', 'city'];
+
+    protected $softCascade = ['logs'];
 
     public function language()
     {
@@ -18,5 +21,10 @@ class Addresses extends Model
     public function profile()
     {
         return $this->belongsTo('Askedio\Tests\App\Profile');
+    }
+
+    public function logs()
+    {
+        return $this->morphMany('Askedio\Tests\App\AuditLog', 'loggable');
     }
 }

--- a/tests/App/AuditLog.php
+++ b/tests/App/AuditLog.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace Askedio\Tests\App;
+
+
+use Illuminate\Database\Eloquent\Model;
+
+class AuditLog extends Model
+{
+    // This model does not use SoftDeletes, and should be HardDeleted if the parent is SoftDeleted
+
+    protected $table = 'audit_logs';
+
+    protected $fillable = ['content'];
+
+    public function logable()
+    {
+        return $this->morphTo();
+    }
+}

--- a/tests/App/AuditLog.php
+++ b/tests/App/AuditLog.php
@@ -1,8 +1,6 @@
 <?php
 
-
 namespace Askedio\Tests\App;
-
 
 use Illuminate\Database\Eloquent\Model;
 

--- a/tests/App/database/migrations/2023-02-28_113215_create_audit-logs_table.php
+++ b/tests/App/database/migrations/2023-02-28_113215_create_audit-logs_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class CreateAuditLogsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::connection()->getSchemaBuilder()->create('audit_logs', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('content', 255);
+            $table->morphs('loggable');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::connection()->getSchemaBuilder()->dropIfExists('audit_logs');
+    }
+}

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -314,9 +314,9 @@ class IntegrationTest extends TestCase
 
     // public function testNotCascadable()
     // {
-        /*
-         * TO-DO: Need a 'test' here, not just code coverage.
-         */
+    /*
+     * TO-DO: Need a 'test' here, not just code coverage.
+     */
     //     (new \Askedio\SoftCascade\SoftCascade())->cascade('notamodel', 'delete');
     // }
 }

--- a/tests/IntegrationTest.php
+++ b/tests/IntegrationTest.php
@@ -44,7 +44,8 @@ class IntegrationTest extends TestCase
         ]);
 
         // lazy
-        Profiles::first()->address()->create(['languages_id' => 1, 'city' => 'Los Angeles']);
+        $address = Profiles::first()->address()->create(['languages_id' => 1, 'city' => 'Los Angeles']);
+        $address->logs()->create(['content' => 'created by ...']);
 
         return $user;
     }
@@ -203,11 +204,14 @@ class IntegrationTest extends TestCase
     {
         $this->createUserRaw();
 
+        $this->assertDatabaseCount('audit_logs', 1);
+
         User::whereIn('id', [1])->delete();
 
         $this->assertDatabaseMissing('users', ['deleted_at' => null]);
         $this->assertDatabaseMissing('profiles', ['deleted_at' => null]);
         $this->assertDatabaseMissing('addresses', ['deleted_at' => null]);
+        $this->assertDatabaseCount('audit_logs', 0);
     }
 
     public function testRestore()


### PR DESCRIPTION
I found an issue, when a SoftDeleted model should delete a NotSoftDeleted model. The `CascadeQueryListener` triggers an update, and tries to update the `deleted_at`-columns, which does only exist, if the model uses SoftDeletes.

My use-case is an edge-case, but still valid, I think. I have this model structure:

```
Group(SoftDeleted) > Device(SoftDeleted) > Logs
```

Logs are not SoftDeleted, as they are very short-lived anyway. They have no SoftDelete, and are lost if the Device is deleted. This works without issues.

If the Group is deleted, it does CascadeDelete the Device, which then should CascadeDelete the Logs (hard delete). But with the current code, subsequent deletes are executed as `update(['deleted_at' => '...'])`-calls, which does not work on models without SoftDelete.

---

This fix changes the behaviour of the detection in the [CascadeQueryListener](src/Listeners/CascadeQueryListener.php) for better differentiation between `delete()` and `update()`-calls, and should resolve this issue.