### PR TITLE
fix: replace try...catch(BadMethodCallException) blocks with a check

### DIFF
--- a/src/Listeners/CascadeQueryListener.php
+++ b/src/Listeners/CascadeQueryListener.php
@@ -4,7 +4,6 @@ namespace Askedio\SoftCascade\Listeners;
 
 use Askedio\SoftCascade\QueryBuilderSoftCascade;
 use Askedio\SoftCascade\Traits\ChecksCascading;
-use BadMethodCallException;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
 use Illuminate\Database\Events\QueryExecuted;
@@ -77,11 +76,10 @@ class CascadeQueryListener
         if (!is_null($event)) {
             $builder = $event['builder'];
 
-            try {
+            // add `withTrashed()`, if the model has SoftDeletes
+            // otherwise, we can just skip it
+            if (method_exists($builder, 'withTrashed') || $builder->hasMacro('withTrashed')) {
                 $builder->withTrashed();
-            } catch (BadMethodCallException $e) {
-                // add `withTrashed()`, if the model has SoftDeletes
-                // otherwise, we can just skip it
             }
 
             $keyName = $builder->getModel()->getKeyName();

--- a/src/SoftCascade.php
+++ b/src/SoftCascade.php
@@ -7,7 +7,6 @@ use Askedio\SoftCascade\Exceptions\SoftCascadeLogicException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeNonExistentRelationActionException;
 use Askedio\SoftCascade\Exceptions\SoftCascadeRestrictedException;
 use Askedio\SoftCascade\Traits\ChecksCascading;
-use BadMethodCallException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphOneOrMany;
@@ -286,10 +285,10 @@ class SoftCascade implements SoftCascadeable
         }
 
         // if the Model does not use SoftDeletes, withTrashed() will be unavailable.
-        try {
+        if (method_exists($builder, 'withTrashed') || $builder->hasMacro('withTrashed')) {
             return $builder->withTrashed();
-        } catch (BadMethodCallException) {
-            return $builder;
         }
+
+        return $builder;
     }
 }


### PR DESCRIPTION
Using BadMethodCallException in this way is not recommended because it may obfuscate underlying issues in the code.

And specifically for me, the call to the non-existent withTrashed() triggers a rare PHP bug which results in a Segmentation fault under very specific and rare circumstances.

This fix checks whether the `withTrashed()` method exists, or is provided through a macro, instead of relying on trying and catching an Exception if it fails.